### PR TITLE
Feature/todo list

### DIFF
--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,0 +1,2 @@
+class Api::V1::BaseApiController < ApplicationController
+end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,2 +1,5 @@
 class Api::V1::BaseApiController < ApplicationController
+	def current_user
+	  @current_user ||= User.first
+	end
 end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::BaseApiController < ApplicationController
-	def current_user
-	  @current_user ||= User.first
-	end
+  def current_user
+    @current_user ||= User.first
+  end
 end

--- a/app/controllers/api/v1/list/homeworks_controller.rb
+++ b/app/controllers/api/v1/list/homeworks_controller.rb
@@ -1,0 +1,8 @@
+module Api::V1
+  class List::HomeworksController < BaseApiController
+		def index
+			homeworks = current_user.homeworks.order(action: :desc)
+			render json: homeworks, each_serializer: APi::V1::HomeworkPreviewSerializer
+		end
+  end
+end

--- a/app/controllers/api/v1/list/homeworks_controller.rb
+++ b/app/controllers/api/v1/list/homeworks_controller.rb
@@ -1,8 +1,8 @@
 module Api::V1
   class List::HomeworksController < BaseApiController
-		def index
-			homeworks = current_user.homeworks.order(action: :desc)
-			render json: homeworks, each_serializer: APi::V1::HomeworkPreviewSerializer
-		end
+    def index
+      homeworks = current_user.homeworks.order(updated_at: :desc)
+      render json: homeworks, each_serializer: Api::V1::HomeworkPreviewSerializer
+    end
   end
 end

--- a/app/serializers/api/v1/homework_preview_serializer.rb
+++ b/app/serializers/api/v1/homework_preview_serializer.rb
@@ -1,0 +1,4 @@
+class Api::V1::HomeworkPreviewSerializer < ActiveModel::Serializer
+  attributes :id, :title, :action, :deadline, :updated_at
+  belongs_to :user, serializer: Api::V1::UserSerializer
+end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -1,0 +1,3 @@
+class Api::V1::UserSerializer < ActiveModel::Serializer
+  attributes :id, :name, :email
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,10 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
       }
+      namespace :list do
+        resources :homeworks
+      end
+
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,6 @@ Rails.application.routes.draw do
       namespace :list do
         resources :homeworks
       end
-
     end
   end
 end

--- a/spec/requests/api/v1/list/homeworks_spec.rb
+++ b/spec/requests/api/v1/list/homeworks_spec.rb
@@ -1,11 +1,24 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Api::V1::List::Homeworks", type: :request do
   describe "GET /api/v1/list/homeworks" do
-    subject { get(api_v1_list_homeworks_path)}
-    let!(:homework1) { create(:homework), user: current_user, updated_at: }
-    it "課題の一覧が取得できる" do
+    subject { get(api_v1_list_homeworks_path) }
 
+    let!(:homework1) { create(:homework, user: current_user, updated_at: 1.days.ago) }
+    let!(:homework2) { create(:homework, user: current_user, updated_at: 3.days.ago) }
+    let!(:homework3) { create(:homework, user: current_user) }
+    let!(:homework4) { create(:homework) }
+    let(:current_user) { create(:user) }
+    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+
+    it "課題の一覧が取得できる" do
+      subject
+      res = JSON.parse(response.body)
+      expect(response).to have_http_status(:ok)
+      expect(res.length).to eq 3
+      expect(res[0].keys).to eq ["id", "title", "action", "deadline", "updated_at", "user"]
+      expect(res.map {|d| d["id"] }).to eq [homework3.id, homework1.id, homework2]
+      expect(res[0]["user"].keys).to eq ["id", "name", "email"]
     end
   end
 end

--- a/spec/requests/api/v1/list/homeworks_spec.rb
+++ b/spec/requests/api/v1/list/homeworks_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::List::Homeworks", type: :request do
+  describe "GET /api/v1/list/homeworks" do
+    subject { get(api_v1_list_homeworks_path)}
+    let!(:homework1) { create(:homework), user: current_user, updated_at: }
+    it "課題の一覧が取得できる" do
+
+    end
+  end
+end


### PR DESCRIPTION
## 概要
 - `base_api_controller` にダミーの current_user メソッドを定義する
    - テストにスタブを定義する
 - `active_model_serializer` を使って、課題の一覧を json で返す機能とテストを実装

## 内容
 - ダミーとして base_api_controller に current_user メソッドを定義して、仮実装として「 users テーブルの一番初めのユーザー」を引用
 - 課題一覧で取得する課題の user_id が current_user の id になるような API を実装
 - 仮実装である base_api_controller の current_user をテストのときだけ別の値として参照する（スタブという）ように実装

## 補足
 - 記事一覧とその他の処理の API に関してはレスポンスの内容を分けたいので、別のシリアライザーを用意する
 - テストで allow_any_instance_of メソッドを使用して current_user を呼び出せるように実装
 - stub の部分が rubocop で指摘されるのだが、この後のタスクで入れ替えてしまうので無視する