### PR TITLE
課題詳細の実装

### DIFF
--- a/app/controllers/api/v1/list/homeworks_controller.rb
+++ b/app/controllers/api/v1/list/homeworks_controller.rb
@@ -4,5 +4,10 @@ module Api::V1
       homeworks = current_user.homeworks.order(updated_at: :desc)
       render json: homeworks, each_serializer: Api::V1::HomeworkPreviewSerializer
     end
+
+    def show
+      homework = Homework.find(params[:id])
+      render json: homework, serializer: Api::V1::HomeworkSerializer
+    end
   end
 end

--- a/app/serializers/api/v1/homework_serializer.rb
+++ b/app/serializers/api/v1/homework_serializer.rb
@@ -1,0 +1,4 @@
+class Api::V1::HomeworkSerializer < ActiveModel::Serializer
+  attributes :id, :title, :body, :action, :deadline, :updated_at
+  belongs_to :user, serializer: Api::V1::UserSerializer
+end

--- a/spec/requests/api/v1/list/homeworks_spec.rb
+++ b/spec/requests/api/v1/list/homeworks_spec.rb
@@ -19,6 +19,35 @@ RSpec.describe "Api::V1::List::Homeworks", type: :request do
       expect(res[0].keys).to eq ["id", "title", "action", "deadline", "updated_at", "user"]
       expect(res.map {|d| d["id"] }).to eq [homework3.id, homework1.id, homework2]
       expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+      expect(res[0]["user"]["id"]).to eq current_user
+    end
+  end
+
+  describe "GET /api/v1/list/homeworks/:id" do
+    subject { get(api_v1_list_homework_path(homework_id)) }
+
+    context "存在する自分の課題の id を指定したとき" do
+      let(:homework_id) { homework.id }
+      let(:homework) { create(:homework) }
+      fit "指定した id の課題の詳細が取得できる" do
+        subject
+        res = JSON.parse(response.body)
+        expect(response).to have_http_status(:ok)
+        expect(res["id"]).to eq homework.id
+        expect(res["title"]).to eq homework.title
+        expect(res["body"]).to eq homework.body
+        expect(res["action"]).to be_present
+        expect(res["deadline"]).to be_present
+        expect(res["updated_at"]).to be_present
+        expect(res["user"].keys).to eq ["id", "name", "email"]
+      end
+    end
+
+    context "存在しない課題の id を指定したとき" do
+      let(:homework_id) { 100000 }
+      fit "課題の詳細が取得できない" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+      end
     end
   end
 end


### PR DESCRIPTION
## 概要
 - 課題の詳細取得機能とテストを実装

## 内容
 - 詳細記事に関する `serializer` を作成
 - 課題の詳細を返す API (show アクション) 及びテストの実装