### PR TITLE
課題作成の実装

### DIFF
--- a/app/controllers/api/v1/list/homeworks_controller.rb
+++ b/app/controllers/api/v1/list/homeworks_controller.rb
@@ -9,5 +9,16 @@ module Api::V1
       homework = Homework.find(params[:id])
       render json: homework, serializer: Api::V1::HomeworkSerializer
     end
+
+		def create
+			homework = current_user.homeworks.create!(homework_params)
+			render json: homework, serializer: Api::V1::HomeworkSerializer
+		end
+
+		private
+
+			def homework_params
+				params.require(:homework).permit(:title, :body, :action, :deadline)
+			end
   end
 end

--- a/spec/requests/api/v1/list/homeworks_spec.rb
+++ b/spec/requests/api/v1/list/homeworks_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Api::V1::List::Homeworks", type: :request do
     context "存在する自分の課題の id を指定したとき" do
       let(:homework_id) { homework.id }
       let(:homework) { create(:homework) }
-      fit "指定した id の課題の詳細が取得できる" do
+      it "指定した id の課題の詳細が取得できる" do
         subject
         res = JSON.parse(response.body)
         expect(response).to have_http_status(:ok)
@@ -45,8 +45,35 @@ RSpec.describe "Api::V1::List::Homeworks", type: :request do
 
     context "存在しない課題の id を指定したとき" do
       let(:homework_id) { 100000 }
-      fit "課題の詳細が取得できない" do
+      it "課題の詳細が取得できない" do
         expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+
+  describe "POST /api/v1/list/homeworks" do
+    subject { post(api_v1_list_homeworks_path, params: params) }
+    context "適切なパラメータを送信したとき" do
+      let(:params) { { homework: attributes_for(:homework) } }
+      let(:current_user) { create(:user) }
+      before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+      it "課題の作成ができる"do
+      expect { subject }.to change { Homework.count }.by(1)
+      res = JSON.parse(response.body)
+      expect(res["title"]).to eq params[:homework][:title]
+      expect(res["body"]).to eq params[:homework][:body]
+      expect(res["action"]).to be_present
+      expect(res["deadline"]).to be_present
+      expect(res["user"]["id"]).to eq current_user.id
+      expect(response).to have_http_status(200)
+      end
+    end
+    context "不適切なパラメータを送信したとき" do
+      let(:params) { attributes_for(:homework) }
+      let(:current_user) { create(:user) }
+      before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+      it "課題の作成に失敗する" do
+        expect { subject }.to raise_error(ActionController::ParameterMissing)
       end
     end
   end


### PR DESCRIPTION
## 概要
 - 課題作成の API とテストの実装
 　- ダミーの`current_user` メソッドを定義する
 　- テストにスタブを定義する

## 内容
 - 新規作成する記事の user_id が current_user の id になるような API を実装
 - 仮実装である base_api_controller の current_user をテストのときだけ別の値として参照する（スタブという）ように実装

