### PR TITLE
課題更新の実装

### DIFF
--- a/app/controllers/api/v1/list/homeworks_controller.rb
+++ b/app/controllers/api/v1/list/homeworks_controller.rb
@@ -15,6 +15,12 @@ module Api::V1
       render json: homework, serializer: Api::V1::HomeworkSerializer
     end
 
+		def update
+			homework = current_user.homeworks.find(params[:id])
+			homework.update!(homework_params)
+      render json: homework, serializer: Api::V1::HomeworkSerializer
+		end
+
     private
 
       def homework_params

--- a/spec/requests/api/v1/list/homeworks_spec.rb
+++ b/spec/requests/api/v1/list/homeworks_spec.rb
@@ -81,4 +81,19 @@ RSpec.describe "Api::V1::List::Homeworks", type: :request do
       end
     end
   end
+  describe "PUT /api/v1/list/homeworks/:id" do
+    subject { put(api_v1_list_homework_path(homework.id), params: params) }
+
+    let(:params) { { homework: { title: "foo", created_at: 1.days.ago } } }
+    let(:current_user) { create(:user) }
+    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    context "課題を更新するとき" do
+      let!(:homework) { create(:homework, user: current_user) }
+      fit "適切な値のみ更新されている" do
+        expect { subject }.to change { homework.reload.title }.from(homework.title).to(params[:homework][:title]) &
+                              not_change { homework.reload.body } &
+                              not_change { homework.reload.created_at }
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  RSpec::Matchers.define_negated_matcher :not_change, :change
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
 ## 概要
 - 課題更新に関する API とテストの実装

## 内容
 - 更新する課題の user_id が current_user の id になるような API を実装
 - `not_change` マッチャをカスタム
 - 送信した値のみ更新され、書き換えを許していない値はそのままであることをテスト