### PR TITLE
課題削除の実装

### DIFF
--- a/app/controllers/api/v1/list/homeworks_controller.rb
+++ b/app/controllers/api/v1/list/homeworks_controller.rb
@@ -15,11 +15,16 @@ module Api::V1
       render json: homework, serializer: Api::V1::HomeworkSerializer
     end
 
-		def update
-			homework = current_user.homeworks.find(params[:id])
-			homework.update!(homework_params)
+    def update
+      homework = current_user.homeworks.find(params[:id])
+      homework.update!(homework_params)
       render json: homework, serializer: Api::V1::HomeworkSerializer
-		end
+    end
+
+    def destroy
+      homework = current_user.homeworks.find(params[:id])
+      homework.destroy!
+    end
 
     private
 

--- a/spec/requests/api/v1/list/homeworks_spec.rb
+++ b/spec/requests/api/v1/list/homeworks_spec.rb
@@ -81,19 +81,34 @@ RSpec.describe "Api::V1::List::Homeworks", type: :request do
       end
     end
   end
+
   describe "PUT /api/v1/list/homeworks/:id" do
     subject { put(api_v1_list_homework_path(homework.id), params: params) }
 
     let(:params) { { homework: { title: "foo", created_at: 1.days.ago } } }
     let(:current_user) { create(:user) }
     before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+
     context "課題を更新するとき" do
       let!(:homework) { create(:homework, user: current_user) }
-      fit "適切な値のみ更新されている" do
+      it "適切な値のみ更新されている" do
         expect { subject }.to change { homework.reload.title }.from(homework.title).to(params[:homework][:title]) &
                               not_change { homework.reload.body } &
                               not_change { homework.reload.created_at }
       end
+    end
+  end
+
+  describe "DELETE /api/v1/list/homeworks/:id" do
+    subject { delete(api_v1_list_homework_path(homework.id)) }
+
+    let!(:homework) { create(:homework, user: current_user) }
+    let(:current_user) { create(:user) }
+    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+
+    it "記事が削除できる" do
+      expect { subject }.to change { Homework.count }.by(-1)
+      expect(response).to have_http_status(:no_content)
     end
   end
 end


### PR DESCRIPTION
## 概要
 - 削除する記事の user_id が current_user の id になるような API を実装
 - stub を使って、テストの実装
 