### PR TITLE
既存の API の修正

### DIFF
--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::BaseApiController < ApplicationController
-  def current_user
-    @current_user ||= User.first
-  end
+  alias_method :current_user, :current_api_v1_user
+  alias_method :authenticate_user!, :authenticate_api_v1_user!
+  alias_method :user_signed_in?, :api_v1_user_signed_in?
 end

--- a/app/controllers/api/v1/list/homeworks_controller.rb
+++ b/app/controllers/api/v1/list/homeworks_controller.rb
@@ -1,6 +1,6 @@
 module Api::V1
   class List::HomeworksController < BaseApiController
-		before_action :authenticate_user!, only: [:index, :create, :update, :destroy]
+    before_action :authenticate_user!, only: [:index, :create, :update, :destroy]
     def index
       homeworks = current_user.homeworks.order(updated_at: :desc)
       render json: homeworks, each_serializer: Api::V1::HomeworkPreviewSerializer

--- a/app/controllers/api/v1/list/homeworks_controller.rb
+++ b/app/controllers/api/v1/list/homeworks_controller.rb
@@ -1,5 +1,6 @@
 module Api::V1
   class List::HomeworksController < BaseApiController
+		before_action :authenticate_user!, only: [:index, :create, :update, :destroy]
     def index
       homeworks = current_user.homeworks.order(updated_at: :desc)
       render json: homeworks, each_serializer: Api::V1::HomeworkPreviewSerializer

--- a/spec/requests/api/v1/list/homeworks_spec.rb
+++ b/spec/requests/api/v1/list/homeworks_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "Api::V1::List::Homeworks", type: :request do
     context "不適切なパラメータを送信したとき" do
       let(:params) { attributes_for(:homework) }
       let(:current_user) { create(:user) }
-      before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+      let(:headers) { current_user.create_new_auth_token }
 
       it "課題の作成に失敗する" do
         expect { subject }.to raise_error(ActionController::ParameterMissing)

--- a/spec/requests/api/v1/list/homeworks_spec.rb
+++ b/spec/requests/api/v1/list/homeworks_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe "Api::V1::List::Homeworks", type: :request do
       expect(response).to have_http_status(:ok)
       expect(res.length).to eq 3
       expect(res[0].keys).to eq ["id", "title", "action", "deadline", "updated_at", "user"]
-      expect(res.map {|d| d["id"] }).to eq [homework3.id, homework1.id, homework2]
+      expect(res.map {|d| d["id"] }).to eq [homework3.id, homework1.id, homework2.id]
       expect(res[0]["user"].keys).to eq ["id", "name", "email"]
-      expect(res[0]["user"]["id"]).to eq current_user
+      expect(res[0]["user"]["id"]).to eq current_user.id
     end
   end
 

--- a/spec/requests/api/v1/list/homeworks_spec.rb
+++ b/spec/requests/api/v1/list/homeworks_spec.rb
@@ -2,15 +2,14 @@ require "rails_helper"
 
 RSpec.describe "Api::V1::List::Homeworks", type: :request do
   describe "GET /api/v1/list/homeworks" do
-    subject { get(api_v1_list_homeworks_path) }
+    subject { get(api_v1_list_homeworks_path, headers: headers) }
 
     let!(:homework1) { create(:homework, user: current_user, updated_at: 1.days.ago) }
     let!(:homework2) { create(:homework, user: current_user, updated_at: 3.days.ago) }
     let!(:homework3) { create(:homework, user: current_user) }
     let!(:homework4) { create(:homework) }
     let(:current_user) { create(:user) }
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
-
+    let(:headers) { current_user.create_new_auth_token }
     it "課題の一覧が取得できる" do
       subject
       res = JSON.parse(response.body)
@@ -52,12 +51,12 @@ RSpec.describe "Api::V1::List::Homeworks", type: :request do
   end
 
   describe "POST /api/v1/list/homeworks" do
-    subject { post(api_v1_list_homeworks_path, params: params) }
+    subject { post(api_v1_list_homeworks_path, params: params, headers: headers) }
 
     context "適切なパラメータを送信したとき" do
       let(:params) { { homework: attributes_for(:homework) } }
       let(:current_user) { create(:user) }
-      before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+      let(:headers) { current_user.create_new_auth_token }
 
       it "課題の作成ができる" do
         expect { subject }.to change { Homework.count }.by(1)
@@ -83,11 +82,11 @@ RSpec.describe "Api::V1::List::Homeworks", type: :request do
   end
 
   describe "PUT /api/v1/list/homeworks/:id" do
-    subject { put(api_v1_list_homework_path(homework.id), params: params) }
+    subject { put(api_v1_list_homework_path(homework.id), params: params, headers: headers) }
 
     let(:params) { { homework: { title: "foo", created_at: 1.days.ago } } }
     let(:current_user) { create(:user) }
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    let(:headers) { current_user.create_new_auth_token }
 
     context "課題を更新するとき" do
       let!(:homework) { create(:homework, user: current_user) }
@@ -100,11 +99,11 @@ RSpec.describe "Api::V1::List::Homeworks", type: :request do
   end
 
   describe "DELETE /api/v1/list/homeworks/:id" do
-    subject { delete(api_v1_list_homework_path(homework.id)) }
+    subject { delete(api_v1_list_homework_path(homework.id), headers: headers) }
 
     let!(:homework) { create(:homework, user: current_user) }
     let(:current_user) { create(:user) }
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    let(:headers) { current_user.create_new_auth_token }
 
     it "記事が削除できる" do
       expect { subject }.to change { Homework.count }.by(-1)


### PR DESCRIPTION
## 概要
 - stub で作った仮実装を devise_token_auth の機能を反映した内容に修正

## 内容
 - devise_token_auth のヘルパーメソッドをエイリアスを指定してそれぞれ反映
 - articles_controller 特定の API を認証済のユーザー以外はアクセスできないようにする
 - 上記内容をふまえて、spec ファイルを修正